### PR TITLE
bump vulnerable deps and fix string console format (closes #56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.1",
       "license": "ISC",
       "dependencies": {
-        "axios": "1.15.0",
+        "axios": "^1.15.2",
         "chalk": "^5.6.2",
         "glob": "^13.0.0",
         "winston": "^3.14.2",
@@ -1630,6 +1630,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1881,13 +1893,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -2675,7 +2688,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3549,9 +3561,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3810,9 +3822,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3992,6 +4004,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -6423,9 +6448,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sndwrks/lumberjack",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "logger powered by winston with a loki integration",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "john mckenna",
   "license": "ISC",
   "dependencies": {
-    "axios": "1.15.0",
+    "axios": "^1.15.2",
     "chalk": "^5.6.2",
     "glob": "^13.0.0",
     "winston": "^3.14.2",

--- a/src/logger.js
+++ b/src/logger.js
@@ -268,6 +268,7 @@ export function beginLogging ({
           label({ label: name }),
           timestamp(),
           splat(),
+          format.json(),
         ),
       }));
     }

--- a/src/logger.string.test.js
+++ b/src/logger.string.test.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-undef */
+import { jest } from '@jest/globals';
+import { configureLogger, beginLogging } from './logger.js';
+
+const config = {
+  logToConsole: {
+    enabled: true,
+    type: 'string',
+  },
+  logLevel: 'silly',
+  service: 'test-string',
+  logToFiles: false,
+};
+
+let writeSpy;
+const captured = [];
+
+beforeAll(() => {
+  configureLogger(config);
+  // Winston's Console transport writes to `console._stdout.write` (see
+  // node_modules/winston/lib/winston/transports/console.js). Under Jest,
+  // `console._stdout` is the buffered console, not `process.stdout`.
+  writeSpy = jest.spyOn(console._stdout, 'write').mockImplementation((chunk) => {
+    captured.push(chunk.toString());
+    return true;
+  });
+});
+
+afterAll(() => {
+  writeSpy.mockRestore();
+});
+
+test('string console type writes parseable JSON to stdout', () => {
+  const logger = beginLogging({ name: 'string-test' });
+
+  logger.info('hello string mode');
+
+  expect(captured.length).toBeGreaterThan(0);
+
+  const line = captured.find((c) => c.includes('hello string mode'));
+  expect(line).toBeDefined();
+
+  const parsed = JSON.parse(line.trim());
+  expect(parsed).toMatchObject({
+    message: 'hello string mode',
+    level: 'info',
+    label: 'string-test',
+    service: 'test-string',
+  });
+  expect(typeof parsed.timestamp).toBe('string');
+});


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled in one PR:

### Security: closes all 16 open Dependabot alerts

- **axios** `1.15.0` → `^1.15.2` (resolves to `1.16.1`). Closes the 10 open axios CVEs (3 high, 6 medium, 1 low), including the prototype-pollution gadget chain in the HTTP adapter (credential injection, header injection, response tampering).
- **follow-redirects** bumped transitively to `1.16.0` (closes GHSA-r4q5-vmmm-2653, auth-header leakage).
- **brace-expansion** bumped transitively to `5.0.6` in `glob` and `nodemon` paths (closes GHSA-jxxr-4gwj-5jf2, `max` DoS bypass).

`npm audit` now reports **0 vulnerabilities**.

Departure from the prior exact-pin convention (PR #64): axios is now pinned with `^` to let future 1.x patch releases flow in without per-CVE bump PRs.

### Bug fix: closes #56

The `string` console branch in `beginLogging()` was building a Winston format chain that ended at `splat()` — no final printf/serializer, so Winston never populated `info[MESSAGE]` and nothing was written. Appending `format.json()` matches the documented intent of the `string` mode ("single-line JSON" per CLAUDE.md) and mirrors the file-transport branch a few lines below.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run test` → 22/22 pass (added `src/logger.string.test.js`)
- [x] Manual smoke: `configureLogger({ logToConsole: { type: 'string', enabled: true }, ... })` + `logger.info('...')` writes one line of JSON to stdout